### PR TITLE
Make vaulttmpfs compatible with kubernetes 1.10+

### DIFF
--- a/main.go
+++ b/main.go
@@ -30,7 +30,11 @@ type vaultSecretFlexVolume struct {
 
 // Init is a no-op here but necessary to satisfy the interface
 func (v vaultSecretFlexVolume) Init() flexvolume.Response {
-	return flexvolume.Succeed("")
+	return flexvolume.Response{
+		Status:       "Success",
+		Message:      "",
+		Capabilities: &flexvolume.Capabilities{Attach: false},
+	}
 }
 
 // Attach is not necessary for this plugin but need to be implemented to satisfy the interface


### PR DESCRIPTION
2 changes done to be compatible with kubernetes 1.10 vaultmpfs interface:

* Now `mount` can handle 2 types of calls: with ou without the `device`. Kubernetes 1.10 don't call mount with the `device` parameter.
* If the command is unknown, returns `NotSupported`.

[Source](https://docs.openshift.org/latest/install_config/persistent_storage/persistent_storage_flex_volume.html)